### PR TITLE
Feat: Button 컴포넌트 구현, globalStyle에 primary 컬러 기본값 추가

### DIFF
--- a/src/components/base/Button/Button.jsx
+++ b/src/components/base/Button/Button.jsx
@@ -1,0 +1,51 @@
+import PropTypes from 'prop-types'
+import theme from '@style/theme'
+import * as S from './Style'
+
+// NOTE: 아무 props도 넘겨주지 않으면 보라색 border에 흰 배경, 검정 글씨임. e.g, 검색 버튼
+// NOTE: color = 폰트 컬러, radius = border-radius, background = background-color
+
+const Button = ({
+  width,
+  height,
+  border,
+  radius,
+  background,
+  color,
+  children,
+  ...props
+}) => {
+  return (
+    <S.ButtonWrapper
+      width={width}
+      height={height}
+      border={border}
+      radius={radius}
+      background={background}
+      color={color}
+      style={{ ...props.style }}
+    >
+      {children}
+    </S.ButtonWrapper>
+  )
+}
+
+Button.propTypes = {
+  width: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  height: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  border: PropTypes.string,
+  radius: PropTypes.bool,
+  background: PropTypes.string,
+  color: PropTypes.string,
+}
+
+Button.defaultProps = {
+  width: '100%',
+  height: '100%',
+  radius: true,
+  border: theme.color.purple,
+  background: '#fff',
+  color: 'inherit',
+}
+
+export default Button

--- a/src/components/base/Button/Style.js
+++ b/src/components/base/Button/Style.js
@@ -1,0 +1,15 @@
+import styled from '@emotion/styled'
+import { style } from '@utils/constants'
+
+export const ButtonWrapper = styled.button`
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  width: ${({ width }) => (typeof width === 'string' ? width : `${width}px`)};
+  height: ${({ height }) =>
+    typeof height === 'string' ? height : `${height}px`};
+  border: ${({ border }) => border && `1px solid ${border}`};
+  border-radius: ${({ radius }) => (radius ? style.BASE_BORDER_RADIUS : 0)};
+  background: ${({ background }) => (background ? background : '#fff')};
+  color: ${({ color }) => color && color};
+`

--- a/src/components/base/index.js
+++ b/src/components/base/index.js
@@ -1,1 +1,2 @@
 export { default as Box } from './Box/Box'
+export { default as Button } from './Button/Button'

--- a/src/style/GlobalStyle.js
+++ b/src/style/GlobalStyle.js
@@ -1,4 +1,6 @@
 import { Global, css } from '@emotion/react'
+import theme from '@style/theme'
+
 const ResetCss = css`
   * {
     box-sizing: border-box;
@@ -6,8 +8,10 @@ const ResetCss = css`
     padding: 0;
   }
 
-  html {
+  html,
+  body {
     font-size: 16px;
+    color: ${theme.color.primary};
   }
 
   ol,

--- a/src/utils/constants/index.js
+++ b/src/utils/constants/index.js
@@ -1,0 +1,3 @@
+export const style = {
+  BASE_BORDER_RADIUS: '3px',
+}


### PR DESCRIPTION
- Closes #3 
<img width="268" alt="image" src="https://user-images.githubusercontent.com/68528752/151339727-d1e4361b-b0cd-43cb-911d-3f0eb6ac966d.png">

- props를 아무것도 넣지 않으면 위와 같음.
<img width="102" alt="image" src="https://user-images.githubusercontent.com/68528752/151339830-0719bb77-78a6-4ca9-bf7c-be8f0dd5d379.png">

- width, height는 숫자, 문자열 둘다 가능
