### PR TITLE
:sparkles:  Calendar 컴포넌트 구현

### DIFF
--- a/src/components/base/Calendar/Calendar.jsx
+++ b/src/components/base/Calendar/Calendar.jsx
@@ -1,5 +1,6 @@
-import React, { useState } from 'react'
 import { DatePicker, DateTimePicker } from 'react-rainbow-components'
+import React, { useState } from 'react'
+import PropTypes from 'prop-types'
 import * as S from './Style'
 
 const Calendar = ({ time }) => {
@@ -23,6 +24,14 @@ const Calendar = ({ time }) => {
       )}
     </S.DatePickerBlock>
   )
+}
+
+Calendar.propTypes = {
+  time: PropTypes.bool,
+}
+
+Calendar.defaultProps = {
+  time: undefined,
 }
 
 export default Calendar

--- a/src/components/base/Calendar/Calendar.jsx
+++ b/src/components/base/Calendar/Calendar.jsx
@@ -1,0 +1,28 @@
+import React, { useState } from 'react'
+import { DatePicker, DateTimePicker } from 'react-rainbow-components'
+import * as S from './Style'
+
+const Calendar = ({ time }) => {
+  const [date, setDate] = useState('')
+  return (
+    <S.DatePickerBlock>
+      {time ? (
+        <DateTimePicker
+          value={date}
+          onChange={(value) => setDate(value)}
+          placeholder="YYYY-MM-DD YY:MM"
+          hour24
+        />
+      ) : (
+        <DatePicker
+          value={date}
+          onChange={(value) => setDate(value)}
+          placeholder="YYYY-MM-DD"
+          hour24
+        />
+      )}
+    </S.DatePickerBlock>
+  )
+}
+
+export default Calendar

--- a/src/components/base/Calendar/Style.js
+++ b/src/components/base/Calendar/Style.js
@@ -1,0 +1,5 @@
+import styled from '@emotion/styled'
+
+export const DatePickerBlock = styled.div`
+  display: inline-block;
+`


### PR DESCRIPTION
Closes #9
react-rainbow-components 이용해서 Calendar 컴포넌트 구현했습니다.

디자인은 이미 적용되어있어 display 값만 수정해주었고,
time를 입력할 경우 날짜만 노출, 미입력시 날짜와 시간이 모두 노출됩니다.

```
<Calendar />
<Calendar time />
```