### PR TITLE
Feat, Fix: AlertModal 구현, useModal return 값 변경

### DIFF
--- a/src/components/base/Box/Style.js
+++ b/src/components/base/Box/Style.js
@@ -7,4 +7,5 @@ export const BoxWrapper = styled.div`
   padding: 10px 20px;
   border: ${({ border }) => `1px solid ${border}`};
   border-radius: 4px;
+  background: #fff;
 `

--- a/src/components/base/Button/Button.jsx
+++ b/src/components/base/Button/Button.jsx
@@ -13,6 +13,7 @@ const Button = ({
   background,
   color,
   children,
+  onClick,
   ...props
 }) => {
   return (
@@ -20,10 +21,11 @@ const Button = ({
       width={width}
       height={height}
       border={border}
-      radius={radius}
+      radius={radius ? 1 : 0}
       background={background}
       color={color}
       style={{ ...props.style }}
+      onClick={onClick}
     >
       {children}
     </S.ButtonWrapper>
@@ -37,6 +39,7 @@ Button.propTypes = {
   radius: PropTypes.bool,
   background: PropTypes.string,
   color: PropTypes.string,
+  onClick: PropTypes.func,
 }
 
 Button.defaultProps = {
@@ -46,6 +49,7 @@ Button.defaultProps = {
   border: theme.color.purple,
   background: '#fff',
   color: 'inherit',
+  onClick: () => {},
 }
 
 export default Button

--- a/src/components/base/Button/Style.js
+++ b/src/components/base/Button/Style.js
@@ -11,4 +11,5 @@ export const ButtonWrapper = styled.button`
   border-radius: ${({ radius, theme }) => (radius ? theme.border.radius : 0)};
   background: ${({ background }) => (background ? background : '#fff')};
   color: ${({ color }) => color && color};
+  cursor: pointer;
 `

--- a/src/components/domain/AlertModal/AlertModal.jsx
+++ b/src/components/domain/AlertModal/AlertModal.jsx
@@ -5,7 +5,7 @@ import theme from '@style/theme'
 import * as S from './Style'
 
 const AlertModal = ({ isCancelButton, isValidate, children }) => {
-  const { isShowing, toggle, setIsShowing } = useModal(true)
+  const { isShowing, toggle } = useModal(true)
 
   return (
     !isValidate &&

--- a/src/components/domain/AlertModal/AlertModal.jsx
+++ b/src/components/domain/AlertModal/AlertModal.jsx
@@ -1,0 +1,59 @@
+import PropTypes from 'prop-types'
+import { Modal, Box, Button } from '@components/base'
+import { useModal } from '@hooks'
+import theme from '@style/theme'
+import * as S from './Style'
+
+const AlertModal = ({ isCancelButton, isValidate, children }) => {
+  const { isShowing, toggle, setIsShowing } = useModal(true)
+
+  return (
+    !isValidate &&
+    isShowing && (
+      <Modal isShowing={isShowing} close={toggle}>
+        <Box
+          width={400}
+          height={200}
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            justifyContent: 'space-between',
+          }}
+        >
+          <S.Text>{children}</S.Text>
+          <S.ButtonWrapper>
+            {' '}
+            {isCancelButton && (
+              <Button
+                color="#fff"
+                background={theme.color.borderDarker}
+                border="inherit"
+                onClick={() => setIsShowing(false)}
+              >
+                취소
+              </Button>
+            )}
+            <Button
+              color="#fff"
+              background={theme.color.purple}
+              border="inherit"
+              onClick={() => setIsShowing(false)}
+            >
+              확인
+            </Button>
+          </S.ButtonWrapper>
+        </Box>
+      </Modal>
+    )
+  )
+}
+
+AlertModal.propTypes = {
+  isCancelButton: PropTypes.bool,
+}
+
+AlertModal.defaultProps = {
+  isCancelButton: true,
+}
+
+export default AlertModal

--- a/src/components/domain/AlertModal/AlertModal.jsx
+++ b/src/components/domain/AlertModal/AlertModal.jsx
@@ -28,7 +28,7 @@ const AlertModal = ({ isCancelButton, isValidate, children }) => {
                 color="#fff"
                 background={theme.color.borderDarker}
                 border="inherit"
-                onClick={() => setIsShowing(false)}
+                onClick={() => toggle(false)}
               >
                 취소
               </Button>

--- a/src/components/domain/AlertModal/AlertModal.jsx
+++ b/src/components/domain/AlertModal/AlertModal.jsx
@@ -37,7 +37,7 @@ const AlertModal = ({ isCancelButton, isValidate, children }) => {
               color="#fff"
               background={theme.color.purple}
               border="inherit"
-              onClick={() => setIsShowing(false)}
+              onClick={() => toggle(false)}
             >
               확인
             </Button>

--- a/src/components/domain/AlertModal/Style.js
+++ b/src/components/domain/AlertModal/Style.js
@@ -1,0 +1,20 @@
+import styled from '@emotion/styled'
+
+export const ButtonWrapper = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  align-items: flex-end;
+
+  & > button {
+    width: 50px;
+    padding: 10px 0;
+
+    &:nth-of-type(2) {
+      margin-left: 5px;
+    }
+  }
+`
+
+export const Text = styled.p`
+  padding-top: 20px;
+`

--- a/src/components/domain/index.js
+++ b/src/components/domain/index.js
@@ -1,3 +1,4 @@
 export { default as FilterInput } from './FilterInput/FilterInput'
 export { default as TagSearchModal } from './TagSearchModal/TagSearchModal'
 export { default as TagList } from './TagList/TagList'
+export { default as AlertModal } from './AlertModal/AlertModal'

--- a/src/hooks/useModal.js
+++ b/src/hooks/useModal.js
@@ -3,8 +3,13 @@ import { useState } from 'react'
 const useModal = (initShow = false) => {
   const [isShowing, setIsShowing] = useState(initShow)
 
-  const toggle = (e) => {
-    const target = e.target
+  const toggle = (eventOrBool) => {
+    if (typeof eventOrBool === 'boolean') {
+      setIsShowing(eventOrBool)
+      return
+    }
+
+    const target = eventOrBool.target
 
     if (target.closest('.close')) {
       setIsShowing(!isShowing)

--- a/src/hooks/useModal.js
+++ b/src/hooks/useModal.js
@@ -16,7 +16,7 @@ const useModal = (initShow = false) => {
     setIsShowing(!isShowing)
   }
 
-  return { isShowing, toggle }
+  return { isShowing, toggle, setIsShowing }
 }
 
 export default useModal

--- a/src/hooks/useModal.js
+++ b/src/hooks/useModal.js
@@ -21,7 +21,7 @@ const useModal = (initShow = false) => {
     setIsShowing(!isShowing)
   }
 
-  return { isShowing, toggle, setIsShowing }
+  return { isShowing, toggle }
 }
 
 export default useModal


### PR DESCRIPTION
- Closes #33 

<img width="458" alt="image" src="https://user-images.githubusercontent.com/68528752/151482746-ddf14230-679a-42f7-b388-2f9d0a5c09c9.png">
useModal 내부에서 이벤트 버블링으로 contents를 찾는데 거기서 return 되버려서 버튼에서 toggle을 작동시킬 수 없음. -> setIsShowing을 리턴값으로 받아와서 사용


## AlertModal 사용법
<img width="472" alt="image" src="https://user-images.githubusercontent.com/68528752/151483137-310b4a54-1bef-4019-9370-4219b13a8f76.png">

`isValidate` boolean 값이 false 일 때 팝업. `isCancelButton`이 false 일 떄 캔슬 버튼 안보임